### PR TITLE
Pass attributes to nested attachments

### DIFF
--- a/src/Refinery.php
+++ b/src/Refinery.php
@@ -126,7 +126,7 @@ abstract class Refinery implements RefineryContract
                     $items = $this->getItemsUsingCallback($raw, $class, $callback);
                 }
 
-                $attachments[$attachment] = ! is_null($items) ? $class->refine($items) : null;
+                $attachments[$attachment] = ! is_null($items) ? $class->with($this->attributes)->refine($items) : null;
             }
         }
 

--- a/tests/FooBarObjectRefinery.php
+++ b/tests/FooBarObjectRefinery.php
@@ -15,7 +15,8 @@ class FooBarObjectRefinery extends Refinery
     protected function setTemplate($item)
     {
         return [
-            'foobar' => $item->foobar
+            'foobar' => $item->foobar,
+            'quux' => $this->quux
         ];
     }
 }

--- a/tests/RefineryTest.php
+++ b/tests/RefineryTest.php
@@ -355,4 +355,28 @@ class RefineryTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('fooBarRaw', $refined);
         $this->assertEquals('foobar', $refined['fooBarRaw']);
     }
+
+    /**
+     * @test
+     */
+    public function it_passes_attributes_to_attachments()
+    {
+        $refinery = new ObjectRefinery();
+
+        $raw = new stdClass();
+
+        $raw->foo = 'foo';
+        $raw->bar = 'bar';
+        $raw->foo1 = 'foo1';
+        $raw->bar1 = 'bar1';
+        $raw->fooBarAttach = new stdClass();
+        $raw->fooBarAttach->foobar = 'foobar';
+
+        $refined = $refinery->bring('fooBarAttach')->with(['quux' => 'quux1'])->refine($raw);
+
+        $this->assertArrayHasKey('fooBarAttach', $refined);
+        $this->assertArrayHasKey('quux', $refined['fooBarAttach']);
+        $this->assertEquals('quux1', $refined['fooBarAttach']['quux']);
+    }
+}
 }

--- a/tests/RefineryTest.php
+++ b/tests/RefineryTest.php
@@ -379,4 +379,3 @@ class RefineryTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('quux1', $refined['fooBarAttach']['quux']);
     }
 }
-}


### PR DESCRIPTION
Pass attributes (->with() values) to nested refinery attachments